### PR TITLE
Add generated declaration file

### DIFF
--- a/react-native-format-currency.d.ts
+++ b/react-native-format-currency.d.ts
@@ -1,7 +1,0 @@
-declare module "react-native-format-currency" {
-  export function formatCurrency(
-    amount: number,
-    code: string
-  ): [string, number, string];
-  export function getSupportedCurrencies(): [{ code: string; name: string }];
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     // "allowJs": true,                             /* Allow javascript files to be compiled. */
     // "checkJs": true,                             /* Report errors in .js files. */
     // "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
-    // "declaration": true,                         /* Generates corresponding '.d.ts' file. */
+    "declaration": true,                         /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                      /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                           /* Generates corresponding '.map' file. */
     // "outFile": "./",                             /* Concatenate and emit output to single file. */


### PR DESCRIPTION
I've made TypeScript emit the declaration file, and removed the handmade one.

Fixes: https://github.com/AwesomeLabs/react-native-format-currency/issues/1