### PR TITLE
Fix return types for FormatCurrencyFunction

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ type FormatCurrencyFunction = ({
 }: {
   amount: number;
   code: string;
-}) => [string, number, string];
+}) => [string, string, string];
 
 export const formatCurrency: FormatCurrencyFunction = ({ amount, code }) => {
   const commaFormatted = String(amount).replace(


### PR DESCRIPTION
This is misleading typescript into thinking that the middle value is a number, when it's actually a string. Neither sufficiently overlaps with the other.