### PR TITLE
Add support for Georgian Lari

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,9 @@ export const formatCurrency: FormatCurrencyFunction = ({ amount, code }) => {
     // uk/great britain pound sterling (ex: £1,234.56)
     GBP: [`£${commaFormatted}`, `${commaFormatted}`, "£"],
 
+    // georgian lari (ex: ₾1,234.56)
+    GEL: [`₾${commaFormatted}`, `${commaFormatted}`, "₾"],
+
     // guatemalan quetzal (ex: Q1,234.56)
     GTQ: [`Q${commaFormatted}`, `${commaFormatted}`, "Q"],
 
@@ -192,9 +195,6 @@ export const formatCurrency: FormatCurrencyFunction = ({ amount, code }) => {
 
     // south african rand (ex: R 1,234.56)
     ZAR: [`R ${commaFormatted}`, `${commaFormatted}`, "R"],
-
-    // georgian lari (ex: ₾1.234,56)
-    GEL: [`₾${periodFormatted}`, `${periodFormatted}`, "₾"],
 
     // default
     DEFAULT: [amount.toString(), amount.toString(), ""],

--- a/src/index.ts
+++ b/src/index.ts
@@ -193,8 +193,8 @@ export const formatCurrency: FormatCurrencyFunction = ({ amount, code }) => {
     // south african rand (ex: R 1,234.56)
     ZAR: [`R ${commaFormatted}`, `${commaFormatted}`, "R"],
 
-    // georgian lari (ex: 1.234,56 ₾)
-    GEL: [`${periodFormatted} ₾`, `${periodFormatted}`, "₾"],
+    // georgian lari (ex: ₾1.234,56)
+    GEL: [`₾${periodFormatted}`, `${periodFormatted}`, "₾"],
 
     // default
     DEFAULT: [amount.toString(), amount.toString(), ""],

--- a/src/index.ts
+++ b/src/index.ts
@@ -193,6 +193,9 @@ export const formatCurrency: FormatCurrencyFunction = ({ amount, code }) => {
     // south african rand (ex: R 1,234.56)
     ZAR: [`R ${commaFormatted}`, `${commaFormatted}`, "R"],
 
+    // georgian lari (ex: 1.234,56 ₾)
+    GEL: [`${periodFormatted} ₾`, `${periodFormatted}`, "₾"],
+
     // default
     DEFAULT: [amount.toString(), amount.toString(), ""],
   };
@@ -253,7 +256,7 @@ export const getSupportedCurrencies = () => {
     // { code: "FJD", name: "Fiji Dollar" },
     // { code: "FKP", name: "Falkland Islands (Malvinas) Pound" },
     { code: "GBP", name: "United Kingdom Pound" },
-    // { code: "GEL", name: "Georgia Lari" },
+    { code: "GEL", name: "Georgia Lari" },
     // { code: "GGP", name: "Guernsey Pound" },
     // { code: "GHS", name: "Ghana Cedi" },
     // { code: "GIP", name: "Gibraltar Pound" },

--- a/test/test.js
+++ b/test/test.js
@@ -533,6 +533,15 @@ describe("formatCurrency function test", () => {
     expect(result).to.eql(["R 1,234,567.89", "1,234,567.89", "R"]);
   });
 
+  it("should return GEL", () => {
+    var result = index.formatCurrency({ amount: 0.56, code: "GEL" });
+    expect(result).to.eql(["0,56 ₾", "0,56", "₾"]);
+    var result = index.formatCurrency({ amount: 1234.56, code: "GEL" });
+    expect(result).to.eql(["1.234,56 ₾", "1.234,56", "₾"]);
+    var result = index.formatCurrency({ amount: 1234567.89, code: "GEL" });
+    expect(result).to.eql(["1.234.567,89 ₾", "1.234.567,89", "₾"]);
+  });
+
   it("should return DEFAULT", () => {
     var result = index.formatCurrency({ amount: 0.56, code: "ZZZ" });
     expect(result).to.eql(["0.56", "0.56", ""]);

--- a/test/test.js
+++ b/test/test.js
@@ -535,11 +535,11 @@ describe("formatCurrency function test", () => {
 
   it("should return GEL", () => {
     var result = index.formatCurrency({ amount: 0.56, code: "GEL" });
-    expect(result).to.eql(["0,56 ₾", "0,56", "₾"]);
+    expect(result).to.eql(["₾0,56", "0,56", "₾"]);
     var result = index.formatCurrency({ amount: 1234.56, code: "GEL" });
-    expect(result).to.eql(["1.234,56 ₾", "1.234,56", "₾"]);
+    expect(result).to.eql(["₾1.234,56", "1.234,56", "₾"]);
     var result = index.formatCurrency({ amount: 1234567.89, code: "GEL" });
-    expect(result).to.eql(["1.234.567,89 ₾", "1.234.567,89", "₾"]);
+    expect(result).to.eql(["₾1.234.567,89", "1.234.567,89", "₾"]);
   });
 
   it("should return DEFAULT", () => {

--- a/test/test.js
+++ b/test/test.js
@@ -182,6 +182,15 @@ describe("formatCurrency function test", () => {
     expect(result).to.eql(["£1,234,567.89", "1,234,567.89", "£"]);
   });
 
+  it("should return GEL", () => {
+    var result = index.formatCurrency({ amount: 0.56, code: "GEL" });
+    expect(result).to.eql(["₾0.56", "0.56", "₾"]);
+    var result = index.formatCurrency({ amount: 1234.56, code: "GEL" });
+    expect(result).to.eql(["₾1,234.56", "1,234.56", "₾"]);
+    var result = index.formatCurrency({ amount: 1234567.89, code: "GEL" });
+    expect(result).to.eql(["₾1,234,567.89", "1,234,567.89", "₾"]);
+  });
+
   it("should return GTQ", () => {
     var result = index.formatCurrency({ amount: 0.56, code: "GTQ" });
     expect(result).to.eql(['Q0.56', '0.56', 'Q' ]);
@@ -531,15 +540,6 @@ describe("formatCurrency function test", () => {
     expect(result).to.eql(["R 1,234.56", "1,234.56", "R"]);
     var result = index.formatCurrency({ amount: 1234567.89, code: "ZAR" });
     expect(result).to.eql(["R 1,234,567.89", "1,234,567.89", "R"]);
-  });
-
-  it("should return GEL", () => {
-    var result = index.formatCurrency({ amount: 0.56, code: "GEL" });
-    expect(result).to.eql(["₾0,56", "0,56", "₾"]);
-    var result = index.formatCurrency({ amount: 1234.56, code: "GEL" });
-    expect(result).to.eql(["₾1.234,56", "1.234,56", "₾"]);
-    var result = index.formatCurrency({ amount: 1234567.89, code: "GEL" });
-    expect(result).to.eql(["₾1.234.567,89", "1.234.567,89", "₾"]);
   });
 
   it("should return DEFAULT", () => {


### PR DESCRIPTION
Added support for Georgian Lari.

Georgian Lari symbol is "₾", it is written after the numeric value and numbers are comma formatted.